### PR TITLE
Include optional parentId when creating issues

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,7 @@ interface CreateIssueArgs {
   description?: string;
   priority?: number;
   status?: string;
+  parentId?: string;
 }
 
 interface UpdateIssueArgs {
@@ -282,7 +283,8 @@ class LinearMCPClient {
       teamId: args.teamId,
       description: args.description,
       priority: args.priority,
-      stateId: args.status
+      stateId: args.status,
+      parentId: args.parentId
     });
 
     const issue = await issuePayload.issue;
@@ -522,7 +524,7 @@ class LinearMCPClient {
 
 const createIssueTool: Tool = {
   name: "linear_create_issue",
-  description: "Creates a new Linear issue with specified details. Use this to create tickets for tasks, bugs, or feature requests. Returns the created issue's identifier and URL. Required fields are title and teamId, with optional description, priority (0-4, where 0 is no priority and 1 is urgent), and status.",
+  description: "Creates a new Linear issue with specified details. Use this to create tickets for tasks, bugs, or feature requests. Returns the created issue's identifier and URL. Required fields are title and teamId, with optional description, priority (0-4, where 0 is no priority and 1 is urgent), status, and parentId for creating sub-issues.",
   inputSchema: {
     type: "object",
     properties: {
@@ -530,7 +532,8 @@ const createIssueTool: Tool = {
       teamId: { type: "string", description: "Team ID" },
       description: { type: "string", description: "Issue description" },
       priority: { type: "number", description: "Priority (0-4)" },
-      status: { type: "string", description: "Issue status" }
+      status: { type: "string", description: "Issue status" },
+      parentId: { type: "string", description: "Optional parent issue ID to create this as a sub-issue" }
     },
     required: ["title", "teamId"]
   }
@@ -920,7 +923,8 @@ async function main() {
               teamId: String(args.teamId),
               description: args.description ? String(args.description) : undefined,
               priority: args.priority ? Number(args.priority) : undefined,
-              status: args.status ? String(args.status) : undefined
+              status: args.status ? String(args.status) : undefined,
+              parentId: args.parentId ? String(args.parentId) : undefined
             };
 
             const issue = await linearClient.createIssue(createArgs);
@@ -942,7 +946,7 @@ async function main() {
               id: String(args.id),
               title: args.title ? String(args.title) : undefined,
               description: args.description ? String(args.description) : undefined,
-            priority: args.priority ? Number(args.priority) : undefined,
+              priority: args.priority ? Number(args.priority) : undefined,
               status: args.status ? String(args.status) : undefined
             };
 
@@ -973,11 +977,10 @@ async function main() {
             return {
               content: [{
                 type: "text",
-                text: `Found ${issues.length} issues:\n${
-                  issues.map((issue: LinearIssueResponse) =>
-                    `- ${issue.identifier}: ${issue.title}\n  Priority: ${issue.priority || 'None'}\n  Status: ${issue.status || 'None'}\n  ${issue.url}`
-                  ).join('\n')
-                }`,
+                text: `Found ${issues.length} issues:\n${issues.map((issue: LinearIssueResponse) =>
+                  `- ${issue.identifier}: ${issue.title}\n  Priority: ${issue.priority || 'None'}\n  Status: ${issue.status || 'None'}\n  ${issue.url}`
+                ).join('\n')
+                  }`,
                 metadata: baseResponse
               }]
             };
@@ -993,11 +996,10 @@ async function main() {
             return {
               content: [{
                 type: "text",
-                text: `Found ${issues.length} issues:\n${
-                  issues.map((issue: LinearIssueResponse) =>
-                    `- ${issue.identifier}: ${issue.title}\n  Priority: ${issue.priority || 'None'}\n  Status: ${issue.stateName}\n  ${issue.url}`
-                  ).join('\n')
-                }`,
+                text: `Found ${issues.length} issues:\n${issues.map((issue: LinearIssueResponse) =>
+                  `- ${issue.identifier}: ${issue.title}\n  Priority: ${issue.priority || 'None'}\n  Status: ${issue.stateName}\n  ${issue.url}`
+                ).join('\n')
+                  }`,
                 metadata: baseResponse
               }]
             };


### PR DESCRIPTION
Hi there, thanks for creating this MCP server! I'm trying it out using Cline in VS Code. I thought it would be useful to be able to specify a parent ID when creating a new issue, so that an existing issue can be broken up into smaller parts.

This PR adds the 'parentId' parameter to the 'create issue' tool and API calls. However, currently the 'parentId' needs to be a UUID, and I'm finding it a little difficult to use the 'search issues' tool - it's timing out for me. I'll try this out more later.

I tested this out by finding the UUID of an existing issue in the browser dev tools (looking at a GraphQL request) so at least including the 'parent ID' in the 'create issues' call is working.


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add optional `parentId` to `CreateIssueArgs` and update `createIssue` method to support sub-issues in Linear.
> 
>   - **Behavior**:
>     - Add optional `parentId` to `CreateIssueArgs` in `index.ts` for creating sub-issues.
>     - Update `createIssue` method in `LinearMCPClient` to include `parentId` when creating issues.
>   - **Tools**:
>     - Update `createIssueTool` description and input schema to include `parentId` as an optional field for sub-issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jerhadf%2Flinear-mcp-server&utm_source=github&utm_medium=referral)<sup> for 88f64c1fdb29036556eb5e1ebcfd5e9d4293d22e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->