### PR TITLE
docs: update API token URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npx @smithery/cli install linear-mcp-server --client claude
 
 ### Manual Installation
 
-1. Create or get a Linear API key for your team: [https://linear.app/YOUR-TEAM/settings/api](https://linear.app/YOUR-TEAM/settings/api)
+1. Create or get a Linear API key for your team: [https://linear.app/YOUR-TEAM/settings/account/security](https://linear.app/YOUR-TEAM/settings/account/security)
 
 2. Add server config to Claude Desktop:
    - MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
@@ -28,10 +28,7 @@ npx @smithery/cli install linear-mcp-server --client claude
   "mcpServers": {
     "linear": {
       "command": "npx",
-      "args": [
-        "-y",
-        "linear-mcp-server"
-      ],
+      "args": ["-y", "linear-mcp-server"],
       "env": {
         "LINEAR_API_KEY": "your_linear_api_key_here"
       }
@@ -45,6 +42,7 @@ npx @smithery/cli install linear-mcp-server --client claude
 ### Tools
 
 1. **`linear_create_issue`**: Create a new Linear issues
+
    - Required inputs:
      - `title` (string): Issue title
      - `teamId` (string): Team ID to create issue in
@@ -54,6 +52,7 @@ npx @smithery/cli install linear-mcp-server --client claude
      - `status` (string): Initial status name
 
 2. **`linear_update_issue`**: Update existing issues
+
    - Required inputs:
      - `id` (string): Issue ID to update
    - Optional inputs:
@@ -63,6 +62,7 @@ npx @smithery/cli install linear-mcp-server --client claude
      - `status` (string): New status name
 
 3. **`linear_search_issues`**: Search issues with flexible filtering
+
    - Optional inputs:
      - `query` (string): Text to search in title/description
      - `teamId` (string): Filter by team
@@ -73,6 +73,7 @@ npx @smithery/cli install linear-mcp-server --client claude
      - `limit` (number, default: 10): Max results
 
 4. **`linear_get_user_issues`**: Get issues assigned to a user
+
    - Optional inputs:
      - `userId` (string): User ID (omit for authenticated user)
      - `includeArchived` (boolean): Include archived issues


### PR DESCRIPTION
## What / Why?

I was going through the setup documented in the `README.md` and noticed the documented URL for creating API token was a bit off. Updated to match what I found in Linear.

See screenshot:

<img width="1840" alt="Screenshot 2025-03-03 at 7 40 38 PM" src="https://github.com/user-attachments/assets/f8ad8a41-9e3b-426b-92c7-b53f948a7647" />


