### PR TITLE
feat: add a new tool to get issue by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ npx @smithery/cli install linear-mcp-server --client claude
      - `createAsUser` (string): Custom username
      - `displayIconUrl` (string): Custom avatar URL
 
+6. **`linear_get_issue`**: Get detailed information about a specific issue
+   - Required inputs:
+     - `id` (string): Issue ID to retrieve
+   - Returns detailed issue information including title, description, priority, status, assignee, team, and URL
+
 ### Resources
 
 - `linear-issue:///{issueId}` - View individual issue details
@@ -109,6 +114,8 @@ Some example prompts you can use with Claude Desktop to interact with Linear:
 4. "Give me a summary of recent updates on the issues for mobile app development" → use `search_issues` to identify the relevant issue(s), then `linear-issue:///{issueId}` fetch the issue details and show recent activity and comments
 
 5. "What's the current workload for the mobile team?" → combine `linear-team:///{teamId}/issues` and `search_issues` to analyze issue distribution and priorities across the mobile team
+
+6. "Get me the full details of issue FOX-1701" → use `linear_get_issue` with the issue ID to retrieve complete information about a specific issue including its current status, assignee, and description
 
 ## Development
 

--- a/index.ts
+++ b/index.ts
@@ -616,6 +616,18 @@ const addCommentTool: Tool = {
   }
 };
 
+const getIssueTool: Tool = {
+  name: "linear_get_issue",
+  description: "Retrieves a specific Linear issue by its ID. Returns detailed information about the issue including title, description, priority, status, assignee, team, and URL. Use this to get full details about a specific issue when you have its ID.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      id: { type: "string", description: "Issue ID" }
+    },
+    required: ["id"]
+  }
+};
+
 const resourceTemplates: ResourceTemplate[] = [
   {
     uriTemplate: "linear-issue:///{issueId}",
@@ -801,6 +813,10 @@ const AddCommentArgsSchema = z.object({
   displayIconUrl: z.string().optional().describe("Optional avatar URL for the comment")
 });
 
+const GetIssueArgsSchema = z.object({
+  id: z.string().describe("Issue ID")
+});
+
 async function main() {
   try {
     dotenv.config();
@@ -904,7 +920,7 @@ async function main() {
     });
 
     server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: [createIssueTool, updateIssueTool, searchIssuesTool, getUserIssuesTool, addCommentTool]
+      tools: [createIssueTool, updateIssueTool, searchIssuesTool, getUserIssuesTool, addCommentTool, getIssueTool]
     }));
 
     server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
@@ -1018,6 +1034,19 @@ async function main() {
               content: [{
                 type: "text",
                 text: `Added comment to issue ${issue?.identifier}\nURL: ${comment.url}`,
+                metadata: baseResponse
+              }]
+            };
+          }
+
+          case "linear_get_issue": {
+            const validatedArgs = GetIssueArgsSchema.parse(args);
+            const issue = await linearClient.getIssue(validatedArgs.id);
+
+            return {
+              content: [{
+                type: "text",
+                text: `Issue Details:\nID: ${issue.identifier}\nTitle: ${issue.title}\nDescription: ${issue.description || 'No description'}\nPriority: ${issue.priority || 'None'}\nStatus: ${issue.status || 'None'}\nAssignee: ${issue.assignee || 'Unassigned'}\nTeam: ${issue.team || 'No team'}\nURL: ${issue.url}`,
                 metadata: baseResponse
               }]
             };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "linear-mcp-server",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@linear/sdk": "^33.0.0",
         "@modelcontextprotocol/sdk": "^1.0.3",


### PR DESCRIPTION
> ## What / Why?
> I wanted to get a single issue by the ID and pass the description to my context . I added the tool to get issue by id .
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `linear_get_issue` tool to retrieve detailed issue information by ID, with updates to `index.ts` and `README.md`.
> 
>   - **Behavior**:
>     - Adds `linear_get_issue` tool in `index.ts` to retrieve detailed information about a specific issue by ID, including title, description, priority, status, assignee, team, and URL.
>     - Updates `README.md` to document `linear_get_issue` tool, including required inputs and example usage.
>   - **Schemas**:
>     - Adds `GetIssueArgsSchema` in `index.ts` for validating input arguments for `linear_get_issue` tool.
>   - **Handlers**:
>     - Updates `main()` in `index.ts` to include `linear_get_issue` in the list of tools handled by the server.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jerhadf%2Flinear-mcp-server&utm_source=github&utm_medium=referral)<sup> for a976e7e454eb24caf83b47b65dcef5ad18d451a9. You can [customize](https://app.ellipsis.dev/jerhadf/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->