### PR TITLE
fix: Resolve status names to workflow state UUIDs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -180,11 +180,49 @@ class RateLimiter {
 class LinearMCPClient {
   private client: LinearClient;
   public readonly rateLimiter: RateLimiter;
+  private stateCache: Map<string, Map<string, string>> = new Map(); // teamId -> (stateName -> stateId)
 
   constructor(apiKey: string) {
     if (!apiKey) throw new Error("LINEAR_API_KEY environment variable is required");
     this.client = new LinearClient({ apiKey });
     this.rateLimiter = new RateLimiter();
+  }
+
+  /**
+   * Resolves a status name (e.g., "Done", "In Progress") to a workflow state UUID.
+   * Caches results per team to avoid repeated API calls.
+   */
+  private async resolveStateId(teamId: string, statusName: string): Promise<string> {
+    // Check cache first
+    const teamCache = this.stateCache.get(teamId);
+    if (teamCache) {
+      const cachedId = teamCache.get(statusName.toLowerCase());
+      if (cachedId) return cachedId;
+    }
+
+    // Fetch workflow states for this team
+    const states = await this.rateLimiter.enqueue(
+      () => this.client.workflowStates({
+        filter: { team: { id: { eq: teamId } } }
+      }),
+      'resolveStateId'
+    );
+
+    // Build cache for this team
+    const newCache = new Map<string, string>();
+    for (const state of states.nodes) {
+      newCache.set(state.name.toLowerCase(), state.id);
+    }
+    this.stateCache.set(teamId, newCache);
+
+    // Look up the requested state
+    const stateId = newCache.get(statusName.toLowerCase());
+    if (!stateId) {
+      const validStates = Array.from(newCache.keys()).join(', ');
+      throw new Error(`Unknown status "${statusName}". Valid statuses for this team: ${validStates}`);
+    }
+
+    return stateId;
   }
 
   private async getIssueDetails(issue: Issue) {
@@ -278,12 +316,18 @@ class LinearMCPClient {
   }
 
   async createIssue(args: CreateIssueArgs) {
+    // Resolve status name to state UUID if provided
+    let stateId: string | undefined;
+    if (args.status) {
+      stateId = await this.resolveStateId(args.teamId, args.status);
+    }
+
     const issuePayload = await this.client.createIssue({
       title: args.title,
       teamId: args.teamId,
       description: args.description,
       priority: args.priority,
-      stateId: args.status
+      stateId
     });
 
     const issue = await issuePayload.issue;
@@ -295,11 +339,19 @@ class LinearMCPClient {
     const issue = await this.client.issue(args.id);
     if (!issue) throw new Error(`Issue ${args.id} not found`);
 
+    // Resolve status name to state UUID if provided
+    let stateId: string | undefined;
+    if (args.status) {
+      const team = await issue.team;
+      if (!team) throw new Error(`Could not get team for issue ${args.id}`);
+      stateId = await this.resolveStateId(team.id, args.status);
+    }
+
     const updatePayload = await issue.update({
       title: args.title,
       description: args.description,
       priority: args.priority,
-      stateId: args.status
+      stateId
     });
 
     const updatedIssue = await updatePayload.issue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "linear-mcp-server",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@linear/sdk": "^33.0.0",
         "@modelcontextprotocol/sdk": "^1.0.3",


### PR DESCRIPTION
## Problem

The `update_issue` and `create_issue` functions pass status names (e.g., "Done", "In Progress") directly as `stateId`, but the Linear API requires UUIDs.

This causes errors like:
```
Linear API error: Argument Validation Error - stateId must be a UUID.
```

## Solution

Added a `resolveStateId()` method that:
1. Queries workflow states for the issue's team
2. Matches the provided status name (case-insensitive)
3. Returns the corresponding UUID
4. Caches results per team to avoid repeated API calls
5. Provides helpful error messages with valid state names if lookup fails

## Changes

- Added `resolveStateId()` private method with caching
- Updated `createIssue()` to resolve status before API call
- Updated `updateIssue()` to get team ID and resolve status before API call

## Testing

- Builds successfully with `npm run build`
- Tested manually with status updates

Fixes #27
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `resolveStateId()` to convert status names to UUIDs in `LinearMCPClient`, updating `createIssue()` and `updateIssue()` to use it.
> 
>   - **Behavior**:
>     - Adds `resolveStateId()` in `LinearMCPClient` to convert status names to UUIDs, caching results per team.
>     - Updates `createIssue()` and `updateIssue()` in `LinearMCPClient` to use `resolveStateId()` for status resolution before API calls.
>   - **Error Handling**:
>     - Throws error with valid state names if status resolution fails in `resolveStateId()`.
>   - **Testing**:
>     - Manual testing with status updates.
>     - Successful build with `npm run build`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jerhadf%2Flinear-mcp-server&utm_source=github&utm_medium=referral)<sup> for a8e60073a9c2f91597f0213d87c006a306311636. You can [customize](https://app.ellipsis.dev/jerhadf/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->